### PR TITLE
0.5.0 更新双ORM，

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,8 @@ APP_URL=http://localhost:8000
 REFERER_CHECK_ENABLED=true
 
 # 数据库配置
+# ORM选择 think 或  eloquent
+ORM_DRIVER=think
 DB_TYPE=mysql
 DB_HOST=127.0.0.1
 DB_PORT=3306

--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -29,7 +29,7 @@ use Framework\Utils\ORMFactory;
 use Illuminate\Database\Capsule\Manager as Capsule;
 #use Illuminate\Support\Facades\DB;
 
-#use think\facade\Db;
+use think\facade\Db;
 
 ##[Auth(roles: ['admin'])]
 ##[Prefix('/secures', middleware: [AuthMiddleware::class])]
@@ -83,8 +83,8 @@ class Home
 	public function html():Response
 	{
 		//thinkORM 和 DB 的测试
-        #$list = Db::name('config')->select();//error：Undefined db config:mysql
-		#dump($list);
+        $list = Db::name('config')->select();//error：Undefined db config:mysql
+		dump($list);
         #dump(($this->db)('config')->where('id' , 1)->select()->toArray());
 		
 		//ThinkORM Model的写法
@@ -128,10 +128,10 @@ class Home
         // dump(app()->getServiceIds()); // 查看所有服务 ID
 
 		//Eloquent 模型的写法
-        #$config = Config::where('id', 1)->first(); //得到 App\Models\Config 可以使用->toArray()转化
+        $config = Config::where('id', 1)->first()->toArray(); //得到 App\Models\Config 可以使用->toArray()转化
 		
 		//use Illuminate\Database\Capsule\Manager as Capsule; //必须要有这个才能下面的操作
-		$config = Capsule::table('config')->where('id', 1)->get();  //得到：Illuminate\Support\Collection 可以使用->toArray()转化
+		//$config = Capsule::table('config')->where('id', 1)->get();  //得到：Illuminate\Support\Collection 可以使用->toArray()转化
 		dump($config);
 		
 		// Eloquent 模型 $this->db->make('config') 小写表名

--- a/app/Models/Config.php
+++ b/app/Models/Config.php
@@ -11,6 +11,10 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model as EloquentModel;
 
+
+use Framework\Utils\BaseModel;
+
+
 class Config extends EloquentModel
 {
     // 移除这行，让 ORM 自动根据模型类名推断表名并应用前缀

--- a/config/database.php
+++ b/config/database.php
@@ -1,6 +1,6 @@
 <?php
 return [
-	'engine'	=>'eloquent', // 'think' or 'eloquent'
+	'engine'	=>'think', // 'think' or 'eloquent'
     // 默认使用的数据库连接配置
     'default'         => 'mysql',
     // 自定义时间查询规则

--- a/config/services.php
+++ b/config/services.php
@@ -30,7 +30,7 @@ return function (ContainerConfigurator $configurator) {
         ->arg('$container', service('service_container'))->public(); // ✅ 显式注入容器自身 注意arg，跟args差异
 
 
-	$databseConfig  = require BASE_PATH . '/config/database.php';
+	//$databseConfig  = require BASE_PATH . '/config/database.php';
 
     // === 注册 ThinkORM 模型工厂服务 ===
 	/*
@@ -65,14 +65,10 @@ return function (ContainerConfigurator $configurator) {
 		
 	);
 
+
     // ✅ 3. 启动所有 Provider（boot）
-    $providerManager->bootProviders($configurator);
-	
-	
-	
-	
-	
-	
+	\Framework\Container\Container::setProviderManager($providerManager);
+
 	/*
     // 工厂服务 0.4.1 版本使用
 	$services->set(Framework\Factory\ThinkORMFactory::class)

--- a/framework/Container/ContainerProviders.php
+++ b/framework/Container/ContainerProviders.php
@@ -110,20 +110,12 @@ class ContainerProviders
     /**
      * 启动所有 Provider 的 boot 方法.
      */
-    public function bootProviders1(ContainerConfigurator $configurator): void
-    {
-        foreach ($this->loadedProviders as $provider) {
-            if (method_exists($provider, 'boot')) {
-                $provider->boot($configurator);
-            }
-        }
-    }
 
     public function bootProviders($container): void
     {
         foreach ($this->loadedProviders as $provider) {
             // 如果是 ContainerConfigurator，则推迟 boot
-            if ($container instanceof ContainerConfigurator) {
+            if ($container instanceof ContainerConfigurator) { 
                 // 暂存，等待 ContainerBuilder 阶段再执行
                 $this->pendingBoot[] = $provider;
                 continue;
@@ -136,6 +128,24 @@ class ContainerProviders
             }
         }
     }
+
+
+	public function bootProviders1($container): void
+	{
+		foreach ($this->loadedProviders as $provider) {
+
+			// 如果还是配置阶段（Configurator），则延迟执行
+			if ($container instanceof ContainerConfigurator) {
+				$this->pendingBoot[] = $provider;
+				continue;
+			}
+
+			// 进入这里说明已经是最终容器（Framework\Container\Container 或 ContainerBuilder）
+			if (method_exists($provider, 'boot')) {
+				$provider->boot($container);
+			}
+		}
+	}
 
     /**
      * 自动获取 Composer 的 PSR-4 映射路径.

--- a/framework/Providers/ORMServiceProvider.php
+++ b/framework/Providers/ORMServiceProvider.php
@@ -6,15 +6,6 @@ namespace Framework\Providers;
 
 use Framework\Container\ServiceProviderInterface;
 use Framework\Utils\ORMFactory;
-
-
-use Illuminate\Container\Container as IlluminateContainer;
-use Illuminate\Database\Capsule\Manager as Capsule;
-use Illuminate\Events\Dispatcher;
-use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\Facades\DB;
-
-
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
@@ -29,6 +20,9 @@ final class ORMServiceProvider implements ServiceProviderInterface
 
         $dbConfig = require BASE_PATH . '/config/database.php';
         $ormType  = $dbConfig['engine'] ?? 'think';
+
+
+
 
         // 注册 ORMFactory
         $services->set(ORMFactory::class)
@@ -47,11 +41,33 @@ final class ORMServiceProvider implements ServiceProviderInterface
                 service(LoggerInterface::class)->nullOnInvalid()
             ])
             ->public();
+			
     }
 
-    public function boot(ContainerInterface $container): void
-    {
 
-    }
+	/*
+	模型基类的别名，暂时不可用
+	*/
+	public function boot(ContainerInterface $container): void
+	{
+		 $engine = config('database.engine', 'eloquent');
+		 
+		//caches('test1', ['name' => 'mike'], 3600);
+		 #dump($engine);
+        // === 再进行 class_alias 切换 ORM Model ===
+		if ($engine === 'eloquent') {
+			class_alias(
+				\Illuminate\Database\Eloquent\Model::class,
+				\Framework\Utils\Model::class
+			);
+		}
 
+		if ($engine === 'thinkorm') {
+			class_alias(
+				\think\Model::class,
+				\Framework\Utils\Model::class
+			);
+		}	 
+
+	}
 }

--- a/framework/Utils/EloquentFactory.php
+++ b/framework/Utils/EloquentFactory.php
@@ -9,7 +9,7 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 use Framework\Utils\ModelFactoryInterface;
 use Illuminate\Container\Container;
-use Illuminate\Events\Dispatcher;
+#use Illuminate\Events\Dispatcher;
 use Illuminate\Support\Facades\Facade;
 
 
@@ -23,8 +23,6 @@ class EloquentFactory implements ModelFactoryInterface
     {
         $this->config = $config;
         $this->logger = $logger;
-
-        
 		
         $container = new Container;
 
@@ -77,7 +75,6 @@ class EloquentFactory implements ModelFactoryInterface
 			'strict'    => $cfg['strict'] ?? true,
 		];
 	}
-
 
     public function make(string $modelClass):mixed
     {

--- a/framework/Utils/ORMFactory.php
+++ b/framework/Utils/ORMFactory.php
@@ -27,7 +27,7 @@ final class ORMFactory implements ModelFactoryInterface
                 break;
         }
     }
-
+	
     public function make(string $modelClass): mixed
     {
         return $this->impl->make($modelClass);

--- a/framework/Utils/ThinkORMFactory.php
+++ b/framework/Utils/ThinkORMFactory.php
@@ -15,9 +15,9 @@ declare(strict_types=1);
  */
 namespace Framework\Utils;
  
-use think\db\BaseQuery;
+#use think\db\BaseQuery;
+#use think\DbManager; // DbManager
 use think\Container;
-use think\DbManager; // DbManager
 use think\Model;
 use think\facade\Db;
 use Framework\Utils\ModelFactoryInterface;
@@ -76,7 +76,7 @@ class ThinkORMFactory implements ModelFactoryInterface
 		$container->bind('model', fn() => $db);
 		*/
 
-		//什么注释掉的写法也可以
+
 		// ✅ 核心：设置静态配置（ThinkORM 4.0 必须！）
 	    $db = \think\facade\Db::setConfig($config);
 


### PR DESCRIPTION
研究了一天，明白了，数据库启动可以采用配置文件切换orm
但是应用层要重写所有的orm方法，属性，事件等，相当于重造一个orm，
所以最后在应用层模型继承给自原来的类即可

`class User extends \Illuminate\Database\Eloquent\Model {}`


或

`class User extends \think\Model {}
`