### PR TITLE
0.5.3 模型类别名

### DIFF
--- a/app/Models/Custom.php
+++ b/app/Models/Custom.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 
 namespace App\Models;
 
-use Framework\Basic\BaseTpORMModel;
-use Framework\Basic\BaseLaORMModel;
+#use Framework\Basic\BaseTpORMModel;
+#use Framework\Basic\BaseLaORMModel;
 
-class Custom extends BaseLaORMModel
+class Custom extends \Framework\Utils\BaseModel
 {
     /**
      * 数据表主键

--- a/config/services.php
+++ b/config/services.php
@@ -44,7 +44,8 @@ return function (ContainerConfigurator $configurator) {
 	// === 再进行 class_alias 切换 ORM Model ===
 	if ($engine === 'laravelORM') {
 		class_alias(
-			\Illuminate\Database\Eloquent\Model::class,
+			//\Illuminate\Database\Eloquent\Model::class, #原始基类
+			\Framework\Basic\BaseLaORMModel::class,	//封装类
 			\Framework\Utils\BaseModel::class,
 			true
 		);
@@ -52,7 +53,8 @@ return function (ContainerConfigurator $configurator) {
 
 	if ($engine === 'thinkORM') {
 		class_alias(
-			\think\Model::class,
+			//\think\Model::class, #原始基类
+			\Framework\Basic\BaseTpORMModel::class,	//封装类
 			\Framework\Utils\BaseModel::class,
 			true
 		);


### PR DESCRIPTION
```
	/*orm 别名切换*/
	$databseConfig  = require BASE_PATH . '/config/database.php';
	$engine = $databseConfig['engine'];
	
	// === 再进行 class_alias 切换 ORM Model ===
	if ($engine === 'laravelORM') {
		class_alias(
			//\Illuminate\Database\Eloquent\Model::class, #原始基类
			\Framework\Basic\BaseLaORMModel::class,	//封装类
			\Framework\Utils\BaseModel::class,
			true
		);
	}

	if ($engine === 'thinkORM') {
		class_alias(
			//\think\Model::class, #原始基类
			\Framework\Basic\BaseTpORMModel::class,	//封装类
			\Framework\Utils\BaseModel::class,
			true
		);
	}	 
```